### PR TITLE
Add Java17 Quarkus multi‑module skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target/
+**/target/
+!.mvn/wrapper/maven-wrapper.jar

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-﻿# clean-architecture-quarkus.
+# Clean Architecture Quarkus
+
+Este repositório é um monorepo em Maven contendo dois módulos:
+
+- **core**: módulo Java 17 sem dependências. Possui os pacotes base `com.github.murilorpaula.core`.
+- **infrastructure**: módulo que depende do `core` e utiliza Quarkus com JPA e driver Postgres.
+
+## Requisitos
+- Java 17+
+- Maven 3.9+
+
+## Como compilar
+
+Execute na raiz do projeto:
+
+```bash
+mvn clean install
+```
+
+Isso compilará os dois módulos. O módulo `infrastructure` gera um aplicativo Quarkus que pode ser executado com:
+
+```bash
+cd infrastructure
+mvn quarkus:dev
+```
+
+## Estrutura de diretórios
+
+```
+├── core
+│   └── src/main/java/com/github/murilorpaula/core
+└── infrastructure
+    └── src/main/java/com/github/murilorpaula/infrastructure
+```

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.github.murilorpaula</groupId>
+        <artifactId>clean-architecture-quarkus</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>core</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/core/src/main/java/com/github/murilorpaula/core/Core.java
+++ b/core/src/main/java/com/github/murilorpaula/core/Core.java
@@ -1,0 +1,8 @@
+package com.github.murilorpaula.core;
+
+/**
+ * Placeholder class for core module.
+ */
+public class Core {
+    // core functionality will be implemented here
+}

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.github.murilorpaula</groupId>
+        <artifactId>clean-architecture-quarkus</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>infrastructure</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.murilorpaula</groupId>
+            <artifactId>core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/GreetingResource.java
+++ b/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/GreetingResource.java
@@ -1,0 +1,12 @@
+package com.github.murilorpaula.infrastructure;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/hello")
+public class GreetingResource {
+    @GET
+    public String hello() {
+        return "Hello";
+    }
+}

--- a/infrastructure/src/main/resources/application.properties
+++ b/infrastructure/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+# Configuração do banco de dados Postgres
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.username=postgres
+quarkus.datasource.password=postgres
+quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/postgres

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.github.murilorpaula</groupId>
+    <artifactId>clean-architecture-quarkus</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>core</module>
+        <module>infrastructure</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <quarkus.plugin.version>3.2.3.Final</quarkus.plugin.version>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.version>3.2.3.Final</quarkus.platform.version>
+    </properties>
+</project>


### PR DESCRIPTION
## Summary
- create parent Maven POM for Java 17
- add `core` module with base package `com.github.murilorpaula.core`
- add `infrastructure` module using Quarkus and depending on `core`
- provide basic REST endpoint and DB configs
- document how to build and run the project

## Testing
- `mvn -q -e install` *(fails: `mvn` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501f06739c832bba4149704309a46f