### PR TITLE
Fix GreetingResource configuration

### DIFF
--- a/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/GreetingResource.java
+++ b/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/GreetingResource.java
@@ -2,8 +2,13 @@ package com.github.murilorpaula.infrastructure;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/hello")
+@ApplicationScoped
+@Produces(MediaType.TEXT_PLAIN)
 public class GreetingResource {
     @GET
     public String hello() {


### PR DESCRIPTION
## Summary
- make GreetingResource a CDI bean so Quarkus can register it

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685021026c58832b8f5559d862070f99