### PR TITLE
Implement basic user CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Este repositório é um monorepo em Maven contendo dois módulos:
 
 ## Requisitos
 - Java 17+
-- (Opcional) Maven 3.9+. Caso não possua Maven instalado utilize o wrapper `./mvnw`.
+- Maven 3.9+ instalado. (Opcionalmente pode-se utilizar o wrapper `./mvnw`.)
 
 ## Como compilar
 
 Execute na raiz do projeto:
 
 ```bash
-./mvnw clean install
+mvn clean install
 ```
 
 As versões do Quarkus são gerenciadas por meio do BOM importado no `pom.xml` da raiz, portanto não é necessário definir versão nas dependências.
@@ -23,7 +23,7 @@ Isso compilará os dois módulos. O módulo `infrastructure` gera um aplicativo 
 
 ```bash
 cd infrastructure
-./mvnw quarkus:dev
+mvn quarkus:dev
 ```
 
 ## Banco de dados com Docker Compose

--- a/core/src/main/java/com/github/murilorpaula/core/user/User.java
+++ b/core/src/main/java/com/github/murilorpaula/core/user/User.java
@@ -1,0 +1,58 @@
+package com.github.murilorpaula.core.user;
+
+import java.util.Objects;
+
+/**
+ * Domain entity representing a user.
+ */
+public class User {
+    private Long id;
+    private String name;
+    private String email;
+
+    public User() {
+    }
+
+    public User(Long id, String name, String email) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return Objects.equals(id, user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/core/src/main/java/com/github/murilorpaula/core/user/UserRepository.java
+++ b/core/src/main/java/com/github/murilorpaula/core/user/UserRepository.java
@@ -1,0 +1,19 @@
+package com.github.murilorpaula.core.user;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Abstraction of user persistence operations.
+ */
+public interface UserRepository {
+    User save(User user);
+
+    Optional<User> findById(Long id);
+
+    List<User> findAll();
+
+    User update(User user);
+
+    void deleteById(Long id);
+}

--- a/core/src/main/java/com/github/murilorpaula/core/user/usecase/UserUseCase.java
+++ b/core/src/main/java/com/github/murilorpaula/core/user/usecase/UserUseCase.java
@@ -1,0 +1,39 @@
+package com.github.murilorpaula.core.user.usecase;
+
+import com.github.murilorpaula.core.user.User;
+import com.github.murilorpaula.core.user.UserRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Encapsula as regras de negócio para operações de usuário.
+ */
+public class UserUseCase {
+    private final UserRepository repository;
+
+    public UserUseCase(UserRepository repository) {
+        this.repository = repository;
+    }
+
+    public User create(User user) {
+        return repository.save(user);
+    }
+
+    public Optional<User> findById(Long id) {
+        return repository.findById(id);
+    }
+
+    public List<User> findAll() {
+        return repository.findAll();
+    }
+
+    public User update(Long id, User user) {
+        user.setId(id);
+        return repository.update(user);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -32,6 +32,16 @@
             <artifactId>jakarta.ws.rs-api</artifactId>
             <version>3.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/user/UserEntity.java
+++ b/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/user/UserEntity.java
@@ -1,0 +1,32 @@
+package com.github.murilorpaula.infrastructure.user;
+
+import com.github.murilorpaula.core.user.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users")
+public class UserEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    public String name;
+
+    public String email;
+
+    public static UserEntity fromDomain(User user) {
+        UserEntity entity = new UserEntity();
+        entity.id = user.getId();
+        entity.name = user.getName();
+        entity.email = user.getEmail();
+        return entity;
+    }
+
+    public User toDomain() {
+        return new User(id, name, email);
+    }
+}

--- a/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/user/UserPanacheRepository.java
+++ b/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/user/UserPanacheRepository.java
@@ -1,0 +1,44 @@
+package com.github.murilorpaula.infrastructure.user;
+
+import com.github.murilorpaula.core.user.User;
+import com.github.murilorpaula.core.user.UserRepository;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class UserPanacheRepository implements PanacheRepository<UserEntity>, UserRepository {
+
+    @Override
+    public User save(User user) {
+        UserEntity entity = UserEntity.fromDomain(user);
+        persist(entity);
+        user.setId(entity.id);
+        return user;
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return Optional.ofNullable(find("id", id).firstResult()).map(UserEntity::toDomain);
+    }
+
+    @Override
+    public List<User> findAll() {
+        return streamAll().map(UserEntity::toDomain).collect(Collectors.toList());
+    }
+
+    @Override
+    public User update(User user) {
+        UserEntity entity = UserEntity.fromDomain(user);
+        getEntityManager().merge(entity);
+        return user;
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        delete("id", id);
+    }
+}

--- a/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/user/UserResource.java
+++ b/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/user/UserResource.java
@@ -1,0 +1,53 @@
+package com.github.murilorpaula.infrastructure.user;
+
+import com.github.murilorpaula.core.user.User;
+import com.github.murilorpaula.core.user.usecase.UserUseCase;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.net.URI;
+import java.util.List;
+
+@Path("/users")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class UserResource {
+
+    @Inject
+    UserUseCase useCase;
+
+    @POST
+    public Response create(User user) {
+        User created = useCase.create(user);
+        return Response.created(URI.create("/users/" + created.getId())).entity(created).build();
+    }
+
+    @GET
+    public List<User> list() {
+        return useCase.findAll();
+    }
+
+    @GET
+    @Path("/{id}")
+    public Response findById(@PathParam("id") Long id) {
+        return useCase.findById(id)
+                .map(Response::ok)
+                .map(Response.ResponseBuilder::build)
+                .orElse(Response.status(Response.Status.NOT_FOUND).build());
+    }
+
+    @PUT
+    @Path("/{id}")
+    public Response update(@PathParam("id") Long id, User user) {
+        User updated = useCase.update(id, user);
+        return Response.ok(updated).build();
+    }
+
+    @DELETE
+    @Path("/{id}")
+    public void delete(@PathParam("id") Long id) {
+        useCase.delete(id);
+    }
+}

--- a/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/user/UserUseCaseBean.java
+++ b/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/user/UserUseCaseBean.java
@@ -1,0 +1,18 @@
+package com.github.murilorpaula.infrastructure.user;
+
+import com.github.murilorpaula.core.user.UserRepository;
+import com.github.murilorpaula.core.user.usecase.UserUseCase;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * CDI bean que expõe {@link UserUseCase} para o restante da aplicação.
+ */
+@ApplicationScoped
+public class UserUseCaseBean extends UserUseCase {
+
+    @Inject
+    public UserUseCaseBean(UserRepository repository) {
+        super(repository);
+    }
+}

--- a/infrastructure/src/main/resources/application.properties
+++ b/infrastructure/src/main/resources/application.properties
@@ -3,3 +3,4 @@ quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=postgres
 quarkus.datasource.password=postgres
 quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/postgres
+quarkus.hibernate-orm.database.generation=drop-and-create

--- a/infrastructure/src/test/java/com/github/murilorpaula/infrastructure/user/UserResourceTest.java
+++ b/infrastructure/src/test/java/com/github/murilorpaula/infrastructure/user/UserResourceTest.java
@@ -1,0 +1,39 @@
+package com.github.murilorpaula.infrastructure.user;
+
+import com.github.murilorpaula.core.user.User;
+import com.github.murilorpaula.core.user.usecase.UserUseCase;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class UserResourceTest {
+
+    @Inject
+    UserUseCase useCase;
+
+    @Test
+    void testCrud() {
+        // create
+        User u = new User(null, "John", "john@test.com");
+        User created = useCase.create(u);
+        assertNotNull(created.getId());
+
+        // list
+        List<User> users = useCase.findAll();
+        assertEquals(1, users.size());
+
+        // update
+        created.setName("Johnny");
+        User updated = useCase.update(created.getId(), created);
+        assertEquals("Johnny", updated.getName());
+
+        // delete
+        useCase.delete(created.getId());
+        assertTrue(useCase.findAll().isEmpty());
+    }
+}

--- a/infrastructure/src/test/resources/application.properties
+++ b/infrastructure/src/test/resources/application.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+quarkus.hibernate-orm.database.generation=drop-and-create


### PR DESCRIPTION
## Summary
- add `User` domain entity and repository interface
- implement `UserEntity` JPA mapping and Panache repository
- expose CRUD endpoints through `UserResource`
- configure DB generation
- add Quarkus tests using H2
- introduce `UserUseCase` in core and expose through `UserUseCaseBean`
- update documentation to use local Maven

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685049c1d66c832ba50148b91688c0d6