### PR TITLE
Resolve method naming conflict in UserRepository

### DIFF
--- a/core/src/main/java/com/github/murilorpaula/core/user/UserRepository.java
+++ b/core/src/main/java/com/github/murilorpaula/core/user/UserRepository.java
@@ -9,11 +9,11 @@ import java.util.Optional;
 public interface UserRepository {
     User save(User user);
 
-    Optional<User> findById(Long id);
+    Optional<User> findUserById(Long id);
 
-    List<User> findAll();
+    List<User> listAllUsers();
 
-    User update(User user);
+    User updateUser(User user);
 
-    void deleteById(Long id);
+    void deleteUserById(Long id);
 }

--- a/core/src/main/java/com/github/murilorpaula/core/user/usecase/UserUseCase.java
+++ b/core/src/main/java/com/github/murilorpaula/core/user/usecase/UserUseCase.java
@@ -21,19 +21,19 @@ public class UserUseCase {
     }
 
     public Optional<User> findById(Long id) {
-        return repository.findById(id);
+        return repository.findUserById(id);
     }
 
     public List<User> findAll() {
-        return repository.findAll();
+        return repository.listAllUsers();
     }
 
     public User update(Long id, User user) {
         user.setId(id);
-        return repository.update(user);
+        return repository.updateUser(user);
     }
 
     public void delete(Long id) {
-        repository.deleteById(id);
+        repository.deleteUserById(id);
     }
 }

--- a/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/user/UserPanacheRepository.java
+++ b/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/user/UserPanacheRepository.java
@@ -21,24 +21,24 @@ public class UserPanacheRepository implements PanacheRepository<UserEntity>, Use
     }
 
     @Override
-    public Optional<User> findById(Long id) {
+    public Optional<User> findUserById(Long id) {
         return Optional.ofNullable(find("id", id).firstResult()).map(UserEntity::toDomain);
     }
 
     @Override
-    public List<User> findAll() {
+    public List<User> listAllUsers() {
         return streamAll().map(UserEntity::toDomain).collect(Collectors.toList());
     }
 
     @Override
-    public User update(User user) {
+    public User updateUser(User user) {
         UserEntity entity = UserEntity.fromDomain(user);
         getEntityManager().merge(entity);
         return user;
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteUserById(Long id) {
         delete("id", id);
     }
 }


### PR DESCRIPTION
## Summary
- avoid PanacheRepository clashes by renaming UserRepository methods
- update UserUseCase and UserPanacheRepository to use the new names

## Testing
- `mvn -q test` *(fails: Could not transfer artifact io.quarkus:quarkus-bom:pom:3.2.3.Final)*

------
https://chatgpt.com/codex/tasks/task_e_68505763ad74832ba47169e04f5d8400