### PR TITLE
Add default constructor for CDI

### DIFF
--- a/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/user/UserUseCaseBean.java
+++ b/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/user/UserUseCaseBean.java
@@ -11,6 +11,14 @@ import jakarta.inject.Inject;
 @ApplicationScoped
 public class UserUseCaseBean extends UserUseCase {
 
+    /**
+     * Default constructor required by CDI. Delegates to {@link UserUseCase#UserUseCase(UserRepository)}
+     * passing {@code null} so the bean can be proxied before the repository is available.
+     */
+    public UserUseCaseBean() {
+        super(null);
+    }
+
     @Inject
     public UserUseCaseBean(UserRepository repository) {
         super(repository);


### PR DESCRIPTION
## Summary
- add a default constructor to `UserUseCaseBean`

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68505c501fe4832b8532da8ab618f6e1