### PR TITLE
Remove maven wrapper references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target/
 **/target/
-!.mvn/wrapper/maven-wrapper.jar
 /.idea/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Este repositório é um monorepo em Maven contendo dois módulos:
 
 ## Requisitos
 - Java 17+
-- Maven 3.9+ instalado. (Opcionalmente pode-se utilizar o wrapper `./mvnw`.)
+- Maven 3.9+ instalado.
 
 ## Como compilar
 


### PR DESCRIPTION
## Summary
- docs: remove leftover `mvnw` mention
- cleanup: drop wrapper entry from `.gitignore`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact io.quarkus:quarkus-bom)*

------
https://chatgpt.com/codex/tasks/task_e_68506070f3e4832bbb1716d9289f3121