### PR TITLE
Atualiza Quarkus e melhora infraestrutura

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Isso compilará os dois módulos. O módulo `infrastructure` gera um aplicativo 
 ./mvnw --project infrastructure quarkus:dev
 ```
 
-Por padrão o perfil utiliza um banco H2 em memória com console acessível em `/h2`.
+Por padrão o perfil utiliza um banco H2 em memória.
 Para executar utilizando o Postgres, ative o perfil `qa`:
 
 ```bash

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -48,11 +48,6 @@
             <artifactId>quarkus-config-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>3.1.0</version>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>

--- a/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/config/UserUseCasesBeans.java
+++ b/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/config/UserUseCasesBeans.java
@@ -1,4 +1,4 @@
-package com.github.murilorpaula.infrastructure.user;
+package com.github.murilorpaula.infrastructure.config;
 
 import com.github.murilorpaula.core.user.repository.UserRepository;
 import com.github.murilorpaula.core.user.usecase.*;

--- a/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/controller/UserResource.java
+++ b/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/controller/UserResource.java
@@ -1,4 +1,4 @@
-package com.github.murilorpaula.infrastructure.user;
+package com.github.murilorpaula.infrastructure.controller;
 
 import com.github.murilorpaula.core.user.domain.User;
 import com.github.murilorpaula.core.user.usecase.CreateUserUseCase;

--- a/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/entity/UserEntity.java
+++ b/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/entity/UserEntity.java
@@ -1,4 +1,4 @@
-package com.github.murilorpaula.infrastructure.user;
+package com.github.murilorpaula.infrastructure.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/mapper/UserMapper.java
+++ b/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/mapper/UserMapper.java
@@ -1,6 +1,7 @@
-package com.github.murilorpaula.infrastructure.user;
+package com.github.murilorpaula.infrastructure.mapper;
 
 import com.github.murilorpaula.core.user.domain.User;
+import com.github.murilorpaula.infrastructure.entity.UserEntity;
 
 public class UserMapper {
     public static UserEntity toEntity(User user) {

--- a/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/repository/UserPanacheRepository.java
+++ b/infrastructure/src/main/java/com/github/murilorpaula/infrastructure/repository/UserPanacheRepository.java
@@ -1,8 +1,10 @@
-package com.github.murilorpaula.infrastructure.user;
+package com.github.murilorpaula.infrastructure.repository;
 
 import com.github.murilorpaula.core.user.domain.User;
 import com.github.murilorpaula.core.user.repository.UserRepository;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import com.github.murilorpaula.infrastructure.entity.UserEntity;
+import com.github.murilorpaula.infrastructure.mapper.UserMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 

--- a/infrastructure/src/main/resources/application.yaml
+++ b/infrastructure/src/main/resources/application.yaml
@@ -14,7 +14,3 @@ quarkus:
   swagger-ui:
     always-include: true
     path: /swagger
-  h2:
-    console:
-      enabled: true
-      path: /h2

--- a/infrastructure/src/test/java/com/github/murilorpaula/infrastructure/controller/UserResourceTest.java
+++ b/infrastructure/src/test/java/com/github/murilorpaula/infrastructure/controller/UserResourceTest.java
@@ -1,4 +1,4 @@
-package com.github.murilorpaula.infrastructure.user;
+package com.github.murilorpaula.infrastructure.controller;
 
 import com.github.murilorpaula.core.user.domain.User;
 import com.github.murilorpaula.core.user.usecase.CreateUserUseCase;

--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus.plugin.version>3.2.3.Final</quarkus.plugin.version>
+        <quarkus.plugin.version>3.20.0</quarkus.plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.2.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.20.0</quarkus.platform.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary
- upgrade Quarkus version to 3.20.0 in project BOM
- confirm jakarta.ws.rs dependency isn't needed
- keep H2 console config removed and maintain package organization

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852d166166c832b97731061b1739964