### PR TITLE
Separate auto version bump workflow

### DIFF
--- a/.github/workflows/auto-bump-version.yml
+++ b/.github/workflows/auto-bump-version.yml
@@ -1,0 +1,48 @@
+name: Auto Bump Version
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  auto-bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Extract PR version
+        id: pr
+        run: |
+          pr_version=$(grep -m 1 '<version>' pom.xml | sed -E 's/.*<version>([^<]+)<\/version>.*/\1/')
+          echo "version=$pr_version" >> "$GITHUB_OUTPUT"
+
+      - name: Get main version
+        run: |
+          git fetch origin main --depth=1
+          main_version=$(git show origin/main:pom.xml | grep -m 1 '<version>' | sed -E 's/.*<version>([^<]+)<\\/version>.*/\1/')
+          echo "MAIN_VERSION=$main_version" >> $GITHUB_ENV
+
+      - name: Bump patch version if equal
+        if: steps.pr.outputs.version == env.MAIN_VERSION
+        run: |
+          new_version=$(python - <<'PY'
+import os, re
+v=os.environ['VERSION']
+m=re.match(r'(\d+)\.(\d+)\.(\d+)(.*)', v)
+if not m:
+    raise SystemExit('Invalid version')
+maj, min, patch, suffix=m.groups()
+print(f"{maj}.{min}.{int(patch)+1}{suffix}")
+PY
+          )
+          ./mvnw -q versions:set -DnewVersion="$new_version" -DgenerateBackupPoms=false
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git commit -am "chore: bump version to $new_version"
+          git push
+        env:
+          VERSION: ${{ steps.pr.outputs.version }}

--- a/.github/workflows/validate-version.yml
+++ b/.github/workflows/validate-version.yml
@@ -1,18 +1,24 @@
 name: Validate Version
 
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Auto Bump Version"]
+    types:
+      - completed
 
 jobs:
   check-version:
+    if: >-
+      {{ github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.pull_requests &&
+      github.event.workflow_run.pull_requests[0].base.ref == 'main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Extract PR version
         id: pr


### PR DESCRIPTION
## Summary
- add `auto-bump-version.yml` workflow that bumps the patch version when needed
- trigger `validate-version.yml` from `workflow_run` so it runs after the bump workflow

## Testing
- `./mvnw -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852ed61c66c832bbc9830d75414f26d