### PR TITLE
Remove Maven dependency from version workflow

### DIFF
--- a/.github/workflows/validate-and-bump-version.yml
+++ b/.github/workflows/validate-and-bump-version.yml
@@ -11,22 +11,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: '17'
       - name: Fetch main branch
         run: git fetch origin main
       - name: Read version from main
         id: main
         run: |
           git show origin/main:pom.xml > main-pom.xml
-          MAIN_VERSION=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version -f main-pom.xml)
+          MAIN_VERSION=$(grep -m1 -oP '(?<=<version>)[^<]+' main-pom.xml)
           echo "MAIN_VERSION=$MAIN_VERSION" >> $GITHUB_ENV
       - name: Read current version
         id: current
         run: |
-          CURRENT_VERSION=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)
+          CURRENT_VERSION=$(grep -m1 -oP '(?<=<version>)[^<]+' pom.xml)
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
       - name: Bump patch version if needed
         if: env.CURRENT_VERSION == env.MAIN_VERSION
@@ -36,7 +32,7 @@ jobs:
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
           PATCH=$((PATCH + 1))
           NEW_VERSION="$MAJOR.$MINOR.$PATCH-SNAPSHOT"
-          mvn -B versions:set -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false
+          sed -i '0,/<version>[^<]*<\/version>/{s/<version>[^<]*<\/version>/<version>'"$NEW_VERSION"'<\/version>/}' pom.xml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "chore: bump version to $NEW_VERSION"
@@ -49,20 +45,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: '17'
       - name: Fetch main branch
         run: git fetch origin main
       - name: Get main version
         run: |
           git show origin/main:pom.xml > main-pom.xml
-          MAIN_VERSION=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version -f main-pom.xml)
+          MAIN_VERSION=$(grep -m1 -oP '(?<=<version>)[^<]+' main-pom.xml)
           echo "MAIN_VERSION=$MAIN_VERSION" >> $GITHUB_ENV
       - name: Get PR version
         run: |
-          CURRENT_VERSION=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)
+          CURRENT_VERSION=$(grep -m1 -oP '(?<=<version>)[^<]+' pom.xml)
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
       - name: Validate version increment
         run: |

--- a/.github/workflows/validate-and-bump-version.yml
+++ b/.github/workflows/validate-and-bump-version.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.head_ref }}
       - name: Fetch main branch
         run: git fetch origin main
       - name: Read version from main
@@ -36,7 +37,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "chore: bump version to $NEW_VERSION"
-          git push
+          git push origin HEAD:${{ github.head_ref }}
 
   check-version:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.murilorpaula</groupId>
     <artifactId>clean-architecture-quarkus</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
## Summary
- refactor CI script to parse and update version using bash tools
- drop setup-java usage

## Testing
- `./mvnw --version` *(fails: Network is unreachable)*
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68532a7e30b4832bb749d856a065764c